### PR TITLE
feat/keyword-read

### DIFF
--- a/src/main/java/com/project/cheerha/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/controller/KeywordController.java
@@ -1,12 +1,26 @@
 package com.project.cheerha.domain.keyword.controller;
 
+import com.project.cheerha.domain.keyword.dto.response.ReadKeywordResponseDto;
+import com.project.cheerha.domain.keyword.service.KeywordService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping
+@RequestMapping("/keywords")
 @RestController
 @RequiredArgsConstructor
 public class KeywordController {
 
+    private final KeywordService keywordService;
+
+    @GetMapping
+    public ResponseEntity<ReadKeywordResponseDto> readAllKeywords() {
+
+        ReadKeywordResponseDto responseDto = keywordService.readAllKeywords();
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/controller/UserKeywordController.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/controller/UserKeywordController.java
@@ -5,11 +5,13 @@ import com.project.cheerha.common.dto.AuthUser;
 import com.project.cheerha.domain.keyword.dto.request.CreateUserKeywordRequestDto;
 import com.project.cheerha.domain.keyword.dto.request.DeleteUserKeywordRequestDto;
 import com.project.cheerha.domain.keyword.dto.response.CreateUserKeywordResponseDto;
+import com.project.cheerha.domain.keyword.dto.response.ReadUserKeywordResponseDto;
 import com.project.cheerha.domain.keyword.service.UserKeywordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,5 +49,16 @@ public class UserKeywordController {
         userKeywordService.deleteUserKeyword(userId, requestDto);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<ReadUserKeywordResponseDto> readAllUserKeywords(
+        @Auth AuthUser authUser
+    ) {
+        Long userId = authUser.id();
+
+        ReadUserKeywordResponseDto responseDto = userKeywordService.readAllUserKeywords(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/KeywordDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/KeywordDto.java
@@ -1,0 +1,8 @@
+package com.project.cheerha.domain.keyword.dto.response;
+
+public record KeywordDto(Long id, String name) {
+
+    public static KeywordDto toKeywordDto(Long id, String name) {
+        return new KeywordDto(id, name);
+    }
+}

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadKeywordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadKeywordResponseDto.java
@@ -2,9 +2,10 @@ package com.project.cheerha.domain.keyword.dto.response;
 
 import java.util.List;
 
-public record ReadKeywordResponseDto(List<String> allKeywordNameList) {
+public record ReadKeywordResponseDto(List<KeywordDto> KeywordList) {
+    // 응답 화면에서 'KeywordList'로 나오도록 'KeywordDtoList' 대신 'KeywordList'로 명명
 
-    public static ReadKeywordResponseDto toDto(List<String> allKeywordNameList) {
-        return new ReadKeywordResponseDto(allKeywordNameList);
+    public static ReadKeywordResponseDto toDto(List<KeywordDto> keywordDtoList) {
+        return new ReadKeywordResponseDto(keywordDtoList);
     }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadKeywordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadKeywordResponseDto.java
@@ -1,0 +1,10 @@
+package com.project.cheerha.domain.keyword.dto.response;
+
+import java.util.List;
+
+public record ReadKeywordResponseDto(List<String> allKeywordNameList) {
+
+    public static ReadKeywordResponseDto toDto(List<String> allKeywordNameList) {
+        return new ReadKeywordResponseDto(allKeywordNameList);
+    }
+}

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadKeywordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadKeywordResponseDto.java
@@ -2,8 +2,7 @@ package com.project.cheerha.domain.keyword.dto.response;
 
 import java.util.List;
 
-public record ReadKeywordResponseDto(List<KeywordDto> KeywordList) {
-    // 응답 화면에서 'KeywordList'로 나오도록 'KeywordDtoList' 대신 'KeywordList'로 명명
+public record ReadKeywordResponseDto(List<KeywordDto> KeywordDtoList) {
 
     public static ReadKeywordResponseDto toDto(List<KeywordDto> keywordDtoList) {
         return new ReadKeywordResponseDto(keywordDtoList);

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadUserKeywordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadUserKeywordResponseDto.java
@@ -2,9 +2,10 @@ package com.project.cheerha.domain.keyword.dto.response;
 
 import java.util.List;
 
-public record ReadUserKeywordResponseDto(List<String> keywordNameListChosenByUser) {
+public record ReadUserKeywordResponseDto(List<KeywordDto> keywordListChosenByUser) {
+    // 응답 화면에서 'keywordListChosenByUser'로 나오도록 위와 같이 변수 명명
 
-    public static ReadUserKeywordResponseDto toDto(List<String> keywordNameListChosenByUser) {
-        return new ReadUserKeywordResponseDto(keywordNameListChosenByUser);
+    public static ReadUserKeywordResponseDto toDto(List<KeywordDto> keywordDtoList) {
+        return new ReadUserKeywordResponseDto(keywordDtoList);
     }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadUserKeywordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadUserKeywordResponseDto.java
@@ -1,0 +1,10 @@
+package com.project.cheerha.domain.keyword.dto.response;
+
+import java.util.List;
+
+public record ReadUserKeywordResponseDto(List<String> keywordNameListChosenByUser) {
+
+    public static ReadUserKeywordResponseDto toDto(List<String> keywordNameListChosenByUser) {
+        return new ReadUserKeywordResponseDto(keywordNameListChosenByUser);
+    }
+}

--- a/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadUserKeywordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/dto/response/ReadUserKeywordResponseDto.java
@@ -2,8 +2,7 @@ package com.project.cheerha.domain.keyword.dto.response;
 
 import java.util.List;
 
-public record ReadUserKeywordResponseDto(List<KeywordDto> keywordListChosenByUser) {
-    // 응답 화면에서 'keywordListChosenByUser'로 나오도록 위와 같이 변수 명명
+public record ReadUserKeywordResponseDto(List<KeywordDto> keywordDtoList) {
 
     public static ReadUserKeywordResponseDto toDto(List<KeywordDto> keywordDtoList) {
         return new ReadUserKeywordResponseDto(keywordDtoList);

--- a/src/main/java/com/project/cheerha/domain/keyword/repository/UserKeywordRepository.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/repository/UserKeywordRepository.java
@@ -1,10 +1,17 @@
 package com.project.cheerha.domain.keyword.repository;
 
 import com.project.cheerha.domain.keyword.entity.UserKeyword;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> {
+
     boolean existsByUserIdAndKeywordId(Long userId, Long keywordId);
 
     boolean existsByUserIdAndId(Long userId, Long userKeywordId);
+
+    @Query("SELECT uk.keyword.id FROM UserKeyword uk WHERE uk.user.id = :userId")
+    List<Long> findKeywordIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/service/KeywordService.java
@@ -1,10 +1,25 @@
 package com.project.cheerha.domain.keyword.service;
 
+import com.project.cheerha.domain.keyword.dto.response.ReadKeywordResponseDto;
+import com.project.cheerha.domain.keyword.entity.Keyword;
+import com.project.cheerha.domain.keyword.repository.KeywordRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class KeywordService {
 
+    private final KeywordRepository keywordRepository;
+
+    @Transactional(readOnly = true)
+    public ReadKeywordResponseDto readAllKeywords() {
+        List<Keyword> allKeywordList = keywordRepository.findAll();
+
+        List<String> keywordNameList = Keyword.extractNameFromEntity(allKeywordList);
+
+        return ReadKeywordResponseDto.toDto(keywordNameList);
+    }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/service/KeywordService.java
@@ -1,5 +1,6 @@
 package com.project.cheerha.domain.keyword.service;
 
+import com.project.cheerha.domain.keyword.dto.response.KeywordDto;
 import com.project.cheerha.domain.keyword.dto.response.ReadKeywordResponseDto;
 import com.project.cheerha.domain.keyword.entity.Keyword;
 import com.project.cheerha.domain.keyword.repository.KeywordRepository;
@@ -16,10 +17,16 @@ public class KeywordService {
 
     @Transactional(readOnly = true)
     public ReadKeywordResponseDto readAllKeywords() {
-        List<Keyword> allKeywordList = keywordRepository.findAll();
+        List<Keyword> keywordList = keywordRepository.findAll();
 
-        List<String> keywordNameList = Keyword.extractNameFromEntity(allKeywordList);
+        List<KeywordDto> keywordDtoList = keywordList.stream()
+            .map(keyword -> KeywordDto.toKeywordDto(
+                    keyword.getId(),
+                    keyword.getName()
+                )
+            )
+            .toList();
 
-        return ReadKeywordResponseDto.toDto(keywordNameList);
+        return ReadKeywordResponseDto.toDto(keywordDtoList);
     }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/service/UserKeywordService.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/service/UserKeywordService.java
@@ -5,6 +5,7 @@ import com.project.cheerha.common.exception.ErrorCode;
 import com.project.cheerha.domain.keyword.dto.request.CreateUserKeywordRequestDto;
 import com.project.cheerha.domain.keyword.dto.request.DeleteUserKeywordRequestDto;
 import com.project.cheerha.domain.keyword.dto.response.CreateUserKeywordResponseDto;
+import com.project.cheerha.domain.keyword.dto.response.KeywordDto;
 import com.project.cheerha.domain.keyword.dto.response.ReadUserKeywordResponseDto;
 import com.project.cheerha.domain.keyword.entity.Keyword;
 import com.project.cheerha.domain.keyword.entity.UserKeyword;
@@ -103,18 +104,21 @@ public class UserKeywordService {
 
         List<Long> keywordIdList = userKeywordRepository.findKeywordIdsByUserId(userId);
 
-        List<String> keywordNameList = keywordIdList.stream()
+        List<KeywordDto> keywordDtoList = keywordIdList.stream()
             .map(keywordId -> {
                     Keyword keyword = keywordRepository.findById(keywordId)
                         .orElseThrow(
                             () -> new CustomException(ErrorCode.KEYWORD_NOT_FOUND)
                         );
 
-                    return keyword.getName();
+                    return KeywordDto.toKeywordDto(
+                        keyword.getId(),
+                        keyword.getName()
+                    );
                 }
             )
             .toList();
 
-        return ReadUserKeywordResponseDto.toDto(keywordNameList);
+        return ReadUserKeywordResponseDto.toDto(keywordDtoList);
     }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/service/UserKeywordService.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/service/UserKeywordService.java
@@ -5,6 +5,7 @@ import com.project.cheerha.common.exception.ErrorCode;
 import com.project.cheerha.domain.keyword.dto.request.CreateUserKeywordRequestDto;
 import com.project.cheerha.domain.keyword.dto.request.DeleteUserKeywordRequestDto;
 import com.project.cheerha.domain.keyword.dto.response.CreateUserKeywordResponseDto;
+import com.project.cheerha.domain.keyword.dto.response.ReadUserKeywordResponseDto;
 import com.project.cheerha.domain.keyword.entity.Keyword;
 import com.project.cheerha.domain.keyword.entity.UserKeyword;
 import com.project.cheerha.domain.keyword.repository.KeywordRepository;
@@ -95,5 +96,25 @@ public class UserKeywordService {
                 userKeywordRepository.deleteById(userKeywordId);
             }
         );
+    }
+
+    @Transactional(readOnly = true)
+    public ReadUserKeywordResponseDto readAllUserKeywords(Long userId) {
+
+        List<Long> keywordIdList = userKeywordRepository.findKeywordIdsByUserId(userId);
+
+        List<String> keywordNameList = keywordIdList.stream()
+            .map(keywordId -> {
+                    Keyword keyword = keywordRepository.findById(keywordId)
+                        .orElseThrow(
+                            () -> new CustomException(ErrorCode.KEYWORD_NOT_FOUND)
+                        );
+
+                    return keyword.getName();
+                }
+            )
+            .toList();
+
+        return ReadUserKeywordResponseDto.toDto(keywordNameList);
     }
 }

--- a/src/main/java/com/project/cheerha/domain/keyword/service/UserKeywordService.java
+++ b/src/main/java/com/project/cheerha/domain/keyword/service/UserKeywordService.java
@@ -49,12 +49,10 @@ public class UserKeywordService {
         List<Keyword> keywordList = new ArrayList<>();
 
         keywordIdList.forEach(keywordId -> {
-                Keyword foundKeyword = keywordRepository.findById(keywordId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.KEYWORD_NOT_FOUND));
+                Keyword foundKeyword = getKeywordById(keywordId);
 
                 if (!isKeywordAlreadyChosen(userId, keywordId)) {
-                    User foundUser = userRepository.findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                    User foundUser = getUserById(userId);
 
                     UserKeyword newUserKeyword = UserKeyword.of(
                         foundUser,
@@ -106,19 +104,24 @@ public class UserKeywordService {
 
         List<KeywordDto> keywordDtoList = keywordIdList.stream()
             .map(keywordId -> {
-                    Keyword keyword = keywordRepository.findById(keywordId)
-                        .orElseThrow(
-                            () -> new CustomException(ErrorCode.KEYWORD_NOT_FOUND)
-                        );
+                    Keyword keyword = getKeywordById(keywordId);
 
-                    return KeywordDto.toKeywordDto(
-                        keyword.getId(),
-                        keyword.getName()
-                    );
+                    return KeywordDto.toKeywordDto(keyword.getId(), keyword.getName());
                 }
-            )
-            .toList();
+            ).toList();
 
         return ReadUserKeywordResponseDto.toDto(keywordDtoList);
+    }
+
+    // todo 리팩토링 시 다른 서비스 레이어로 분리 필요
+    private Keyword getKeywordById(Long keywordId) {
+        return keywordRepository.findById(keywordId)
+            .orElseThrow(() -> new CustomException(ErrorCode.KEYWORD_NOT_FOUND));
+    }
+
+    // todo 리팩토링 시 다른 서비스 레이어로 분리 필요
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## #️⃣ Kan Board Number

7, 20, 21

## 📝 요약
모든 키워드 조회 (R) 구현 - Postman 테스트 완료
사용자가 알림으로 등록한 채용 키워드 목록 조회 (R) 구현 완료 - Postman 테스트 완료
조회할 때 키워드의 id와 이름을 함께 반환하도록 리팩토링 완료 


## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

현재 사용자가 알림 받을 키워드를 등록할 때에는,
{
    "keywordIdList": [1, 3]
}
위와 같이 입력하고,
{
      "keywordList": [
          "Java",
          "Kafka"
      ]
}
응답은 예시처럼 이름만 나오는데요. 여기서 응답할 때에도 id를 함께 전달해줘야 할지 의견을 구하고 싶습니다:)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [ ] 지현
- [x] 리은
- [ ] 승찬
- [x] 주양

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 전체 키워드 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  - 사용자 별로 키워드 정보를 확인할 수 있는 기능이 도입되었습니다.
  - 향상된 응답 구조를 통해 키워드 데이터 전달이 개선되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->