### PR TITLE
V2/refactor/search history

### DIFF
--- a/src/main/java/com/project/cheerha/CheerhaApplication.java
+++ b/src/main/java/com/project/cheerha/CheerhaApplication.java
@@ -6,8 +6,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 @EnableConfigurationProperties({JwtSecurityProperties.class, BcryptSecurityProperties.class})
 public class CheerhaApplication {

--- a/src/main/java/com/project/cheerha/common/config/RedisConfig.java
+++ b/src/main/java/com/project/cheerha/common/config/RedisConfig.java
@@ -5,7 +5,10 @@ import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.config.Config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
@@ -16,8 +19,17 @@ public class RedisConfig {
         Config config = new Config();
         config.setCodec(new JsonJacksonCodec());
         config.useSingleServer()
-                .setAddress("redis://redis:6379");  //도커로 실행할 경우
-//                .setAddress("redis://localhost:6379");    //로컬에서 실행할 경우
+//                .setAddress("redis://redis:6379");  //도커로 실행할 경우
+                .setAddress("redis://localhost:6379");    //로컬에서 실행할 경우
         return org.redisson.Redisson.create(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
     }
 }

--- a/src/main/java/com/project/cheerha/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/project/cheerha/domain/history/controller/HistoryController.java
@@ -3,7 +3,6 @@ package com.project.cheerha.domain.history.controller;
 import com.project.cheerha.common.annotation.Auth;
 import com.project.cheerha.common.dto.ApiResponseDto;
 import com.project.cheerha.common.dto.AuthUser;
-import com.project.cheerha.domain.history.dto.response.ReadHistoryResponseDto;
 import com.project.cheerha.domain.history.service.HistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,23 +20,17 @@ public class HistoryController {
     private final HistoryService historyService;
 
     @GetMapping
-    public ResponseEntity<ApiResponseDto<List<ReadHistoryResponseDto>>> readAllHistories(
+    public ResponseEntity<ApiResponseDto<List<String>>> readAllHistories(
             @Auth AuthUser authUser
     ) {
         Long userId = authUser.id();
-        List<ReadHistoryResponseDto> dtoList = historyService.readAllHistories(userId);
-        return ApiResponseDto.success(dtoList);
-    }
+        List<String> SearchTermsList = historyService.getRecentSearchTerms(userId);
 
-    @GetMapping("/redis")
-    public ResponseEntity<ApiResponseDto<List<String>>> readAllRedisHistories(
-        @Auth AuthUser authUser
-    ) {
-        Long userId = authUser.id();
+        if (SearchTermsList.isEmpty()) {
+            SearchTermsList = historyService.getRecentSearchTerms(userId); // 다시 조회
+        }
 
-        List<String> recentSearchTermsList = historyService.getRecentSearchTerms(userId);
-
-        return ApiResponseDto.success(recentSearchTermsList);
+        return ApiResponseDto.success(SearchTermsList);
     }
 
 }

--- a/src/main/java/com/project/cheerha/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/project/cheerha/domain/history/controller/HistoryController.java
@@ -19,6 +19,15 @@ public class HistoryController {
 
     private final HistoryService historyService;
 
+    /**
+     * 사용자의 최근 검색어 목록을 조회하는 API입니다.
+     *
+     * Redis에 저장된 최근 검색어 목록을 반환합니다.
+     * 첫번째 조회 시 검색어가 없다면, 다시 조회하여 DB에서 검색어 목록을 가져옵니다.
+     *
+     * @param authUser 로그인한 유저의 정보
+     * @return 최근 검색어 목록 (10개)
+     */
     @GetMapping
     public ResponseEntity<ApiResponseDto<List<String>>> readAllHistories(
             @Auth AuthUser authUser
@@ -27,7 +36,7 @@ public class HistoryController {
         List<String> SearchTermsList = historyService.getRecentSearchTerms(userId);
 
         if (SearchTermsList.isEmpty()) {
-            SearchTermsList = historyService.getRecentSearchTerms(userId); // 다시 조회
+            SearchTermsList = historyService.getRecentSearchTerms(userId);
         }
 
         return ApiResponseDto.success(SearchTermsList);

--- a/src/main/java/com/project/cheerha/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/project/cheerha/domain/history/controller/HistoryController.java
@@ -28,4 +28,16 @@ public class HistoryController {
         List<ReadHistoryResponseDto> dtoList = historyService.readAllHistories(userId);
         return ApiResponseDto.success(dtoList);
     }
+
+    @GetMapping("/redis")
+    public ResponseEntity<ApiResponseDto<List<String>>> readAllRedisHistories(
+        @Auth AuthUser authUser
+    ) {
+        Long userId = authUser.id();
+
+        List<String> recentSearchTermsList = historyService.getRecentSearchTerms(userId);
+
+        return ApiResponseDto.success(recentSearchTermsList);
+    }
+
 }

--- a/src/main/java/com/project/cheerha/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/com/project/cheerha/domain/history/repository/HistoryRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
-    // TODO: 현재는 전체 조회인데 상위 몇개까지 조회하도록 정하는 것도 좋을 것 같습니다!
-    List<History> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    List<History> findTop10ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryScheduler.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryScheduler.java
@@ -1,0 +1,49 @@
+package com.project.cheerha.domain.history.service;
+
+import com.project.cheerha.domain.history.entity.History;
+import com.project.cheerha.domain.history.repository.HistoryRepository;
+import com.project.cheerha.domain.user.entity.User;
+import com.project.cheerha.domain.user.service.UserFindByService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class HistoryScheduler {
+
+    private final UserFindByService userFindByService;
+    private final HistoryRepository historyRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * Redis에 저장된 검색를 주기적으로 DB에 저장하는 스케줄러 메서드입니다.
+     *
+     * 30분마다 실행이 되며, 각 사용자의 검색어를 Redis에서 가져와서 DB에 저장합니다.
+     * 이미 저장된 검색어는 중복 저장하지 않습니다.
+     */
+    @Scheduled(fixedRate = 1800000) // 30분마다 실행
+    public void saveSearchHistoryToDb() {
+        Set<String> keys = redisTemplate.keys("user:*:search_history");
+
+        if (keys != null) {
+            for (String key : keys) {
+                Long userId = Long.parseLong(key.split(":")[1]);
+                User user = userFindByService.findById(userId);
+
+                Set<String> searchTerms = redisTemplate.opsForZSet().range(key, 0, -1);
+
+                if (searchTerms != null) {
+                    searchTerms.forEach(term -> {
+                        if (!historyRepository.existsByUserIdAndName(userId, term)) {
+                            historyRepository.save(History.toEntity(user, term));
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
@@ -2,11 +2,8 @@ package com.project.cheerha.domain.history.service;
 
 import com.project.cheerha.domain.history.entity.History;
 import com.project.cheerha.domain.history.repository.HistoryRepository;
-import com.project.cheerha.domain.user.entity.User;
-import com.project.cheerha.domain.user.service.UserFindByService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -18,12 +15,21 @@ import java.util.stream.Collectors;
 public class HistoryService {
 
     private final HistoryRepository historyRepository;
-    private final UserFindByService userFindByService;
     private final RedisTemplate<String, String> redisTemplate;
 
     private static final int MAX_HISTORY_SIZE = 10; // 최대 저장 개수
     private static final long EXPIRATION_TIME = 3600; // 1시간(초 단위)
 
+    /**
+     * 사용자의 검색어를 Redis에 저장하는 메서드입니다.
+     *
+     * 검색어는 저장된 시간을 기준으로 정렬됩니다.
+     * 최대 10개까지 저장되, 초과 시 가장 오래된 검색어가 삭제됩니다.
+     * 검색 기록은 일정 시간이 지나면 자동으로 만료됩니다.
+     *
+     * @param userId 검색어를 저장할 유저의 Id
+     * @param searchTerm 사용자가 입력한 검색어
+     */
     public void saveSearchTerm(Long userId, String searchTerm) {
         String key = "user:" + userId + ":search_history";
         long timestamp = System.currentTimeMillis();
@@ -38,6 +44,16 @@ public class HistoryService {
         redisTemplate.expire(key, EXPIRATION_TIME, TimeUnit.SECONDS);
     }
 
+    /**
+     * 사용자의 최근 검색어 목록을 조회하는 메서드입니다.
+     *
+     * Redis에 저장된 검색어 목록을 조회하며, 최대 10개까지 반환 가능합니다.
+     * Redis에 검색어가 없을 경우, DB에서 상위 10개를 조회하여 Redis에 저장합니다.
+     * DB에서 가져온 검색어는 저장된 순서를 유지하기 위해 정렬 후 Redis에 역순으로 저장됩니다.
+     *
+     * @param userId 검색어를 조회할 유저의 Id
+     * @return 최근 검색한 검색어 목록 (10개)
+     */
     public List<String> getRecentSearchTerms(Long userId) {
         String key = "user:" + userId + ":search_history";
 
@@ -56,28 +72,6 @@ public class HistoryService {
         }
 
         return new ArrayList<>(searchTerms);
-    }
-
-    @Scheduled(fixedRate = 1800000) // 30분마다 실행
-    public void saveSearchHistoryToDb() {
-        Set<String> keys = redisTemplate.keys("user:*:search_history");
-
-        if (keys != null) {
-            for (String key : keys) {
-                Long userId = Long.parseLong(key.split(":")[1]); // "user:123:search_history" → userId 추출
-                User user = userFindByService.findById(userId);
-
-                Set<String> searchTerms = redisTemplate.opsForZSet().range(key, 0, -1);
-
-                if (searchTerms != null) {
-                    searchTerms.forEach(term -> {
-                        if (!historyRepository.existsByUserIdAndName(userId, term)) {
-                            historyRepository.save(History.toEntity(user, term));
-                        }
-                    });
-                }
-            }
-        }
     }
 
 }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
@@ -4,15 +4,22 @@ import com.project.cheerha.domain.history.dto.response.ReadHistoryResponseDto;
 import com.project.cheerha.domain.history.entity.History;
 import com.project.cheerha.domain.history.repository.HistoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class HistoryService {
 
     private final HistoryRepository historyRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final int MAX_HISTORY_SIZE = 10; // 최대 저장 개수
+    private static final long EXPIRATION_TIME = 3600; // 1시간(초 단위)
 
     public List<ReadHistoryResponseDto> readAllHistories(Long userId) {
         List<History> historyList = historyRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
@@ -20,6 +27,28 @@ public class HistoryService {
         return historyList.stream()
             .map(ReadHistoryResponseDto::toDto)
             .toList();
+    }
+
+    public void saveSearchTerm(Long userId, String searchTerm) {
+        String key = "user:" + userId + ":search_history";
+        long timestamp = System.currentTimeMillis();
+
+        redisTemplate.opsForZSet().add(key, searchTerm, timestamp);
+
+        Long size = redisTemplate.opsForZSet().zCard(key);
+        if (size != null && size > MAX_HISTORY_SIZE) {
+            redisTemplate.opsForZSet().removeRange(key, 0, size - MAX_HISTORY_SIZE - 1);
+        }
+
+        redisTemplate.expire(key, EXPIRATION_TIME, TimeUnit.SECONDS);
+    }
+
+    public List<String> getRecentSearchTerms(Long userId) {
+        String key = "user:" + userId + ":search_history";
+
+        Set<String> searchTerms = redisTemplate.opsForZSet().reverseRange(key, 0, 9);
+
+        return searchTerms != null ? searchTerms.stream().toList() : List.of();
     }
 
 }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
@@ -1,33 +1,28 @@
 package com.project.cheerha.domain.history.service;
 
-import com.project.cheerha.domain.history.dto.response.ReadHistoryResponseDto;
 import com.project.cheerha.domain.history.entity.History;
 import com.project.cheerha.domain.history.repository.HistoryRepository;
+import com.project.cheerha.domain.user.entity.User;
+import com.project.cheerha.domain.user.service.UserFindByService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class HistoryService {
 
     private final HistoryRepository historyRepository;
+    private final UserFindByService userFindByService;
     private final RedisTemplate<String, String> redisTemplate;
 
     private static final int MAX_HISTORY_SIZE = 10; // 최대 저장 개수
     private static final long EXPIRATION_TIME = 3600; // 1시간(초 단위)
-
-    public List<ReadHistoryResponseDto> readAllHistories(Long userId) {
-        List<History> historyList = historyRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
-
-        return historyList.stream()
-            .map(ReadHistoryResponseDto::toDto)
-            .toList();
-    }
 
     public void saveSearchTerm(Long userId, String searchTerm) {
         String key = "user:" + userId + ":search_history";
@@ -47,8 +42,42 @@ public class HistoryService {
         String key = "user:" + userId + ":search_history";
 
         Set<String> searchTerms = redisTemplate.opsForZSet().reverseRange(key, 0, 9);
+        if (searchTerms == null || searchTerms.isEmpty()) {
+            List<String> dbSearchTerms = historyRepository.findTop10ByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .sorted(Comparator.comparing(History::getCreatedAt))
+                .map(History::getName)
+                .collect(Collectors.toList());
 
-        return searchTerms != null ? searchTerms.stream().toList() : List.of();
+            dbSearchTerms.forEach(term -> saveSearchTerm(userId, term));
+            Collections.reverse(dbSearchTerms);
+
+            return dbSearchTerms;
+        }
+
+        return new ArrayList<>(searchTerms);
+    }
+
+    @Scheduled(fixedRate = 1800000) // 30분마다 실행
+    public void saveSearchHistoryToDb() {
+        Set<String> keys = redisTemplate.keys("user:*:search_history");
+
+        if (keys != null) {
+            for (String key : keys) {
+                Long userId = Long.parseLong(key.split(":")[1]); // "user:123:search_history" → userId 추출
+                User user = userFindByService.findById(userId);
+
+                Set<String> searchTerms = redisTemplate.opsForZSet().range(key, 0, -1);
+
+                if (searchTerms != null) {
+                    searchTerms.forEach(term -> {
+                        if (!historyRepository.existsByUserIdAndName(userId, term)) {
+                            historyRepository.save(History.toEntity(user, term));
+                        }
+                    });
+                }
+            }
+        }
     }
 
 }

--- a/src/main/java/com/project/cheerha/domain/jobOpening/service/JobOpeningService.java
+++ b/src/main/java/com/project/cheerha/domain/jobOpening/service/JobOpeningService.java
@@ -5,8 +5,6 @@ import com.project.cheerha.domain.jobOpening.dto.request.ReadJobOpeningRequestDt
 import com.project.cheerha.domain.jobOpening.dto.response.ReadJobOpeningResponseDto;
 import com.project.cheerha.domain.jobOpening.entity.JobOpening;
 import com.project.cheerha.domain.jobOpening.repository.JobOpeningRepository;
-import com.project.cheerha.domain.user.entity.User;
-import com.project.cheerha.domain.user.service.UserFindByService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -20,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class  JobOpeningService {
 
     private final JobOpeningRepository jobOpeningRepository;
-    private final UserFindByService userFindByIdService;
     private final JobOpeningFindByService jobOpeningFindByService;
     private final HistoryService historyService;
 
@@ -40,14 +37,23 @@ public class  JobOpeningService {
         return url;
     }
 
+    /**
+     * 채용 공고 목록을 조회하는 메서드입니다.
+     *
+     * requestDto에 값이 포함되면 해당 조건을 기준으로 필터링이 적용됩니다.
+     * searchTerm이 존재하면 해당 검색어를 Redis에 저장합니다.
+     *
+     * @param requestDto 조회 조건을 포함한 요청 Dto
+     * @param userId 검색어 저장을 위한 유저의 Id
+     * @param pageable 페이지 요청 정보 (페이지 번호, 페이지 크기)
+     * @return 필터링된 채용 공고 목록
+     */
     @Transactional
     public Page<ReadJobOpeningResponseDto> readJobOpenings(
             ReadJobOpeningRequestDto requestDto,
             Long userId,
             Pageable pageable
     ) {
-        User user = userFindByIdService.findById(userId);
-
         if (requestDto.getSearchTerm() != null) {
             historyService.saveSearchTerm(userId, requestDto.getSearchTerm());
         }

--- a/src/main/java/com/project/cheerha/domain/jobOpening/service/JobOpeningService.java
+++ b/src/main/java/com/project/cheerha/domain/jobOpening/service/JobOpeningService.java
@@ -1,7 +1,5 @@
 package com.project.cheerha.domain.jobOpening.service;
 
-import com.project.cheerha.domain.history.entity.History;
-import com.project.cheerha.domain.history.repository.HistoryRepository;
 import com.project.cheerha.domain.history.service.HistoryService;
 import com.project.cheerha.domain.jobOpening.dto.request.ReadJobOpeningRequestDto;
 import com.project.cheerha.domain.jobOpening.dto.response.ReadJobOpeningResponseDto;
@@ -22,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class  JobOpeningService {
 
     private final JobOpeningRepository jobOpeningRepository;
-    private final HistoryRepository historyRepository;
     private final UserFindByService userFindByIdService;
     private final JobOpeningFindByService jobOpeningFindByService;
     private final HistoryService historyService;
@@ -53,9 +50,6 @@ public class  JobOpeningService {
 
         if (requestDto.getSearchTerm() != null) {
             historyService.saveSearchTerm(userId, requestDto.getSearchTerm());
-
-            History history = History.toEntity(user, requestDto.getSearchTerm());
-            historyRepository.save(history);
         }
 
         Page<ReadJobOpeningResponseDto> dtoPage = jobOpeningRepository.findAllByCondition(

--- a/src/main/java/com/project/cheerha/domain/jobOpening/service/JobOpeningService.java
+++ b/src/main/java/com/project/cheerha/domain/jobOpening/service/JobOpeningService.java
@@ -2,6 +2,7 @@ package com.project.cheerha.domain.jobOpening.service;
 
 import com.project.cheerha.domain.history.entity.History;
 import com.project.cheerha.domain.history.repository.HistoryRepository;
+import com.project.cheerha.domain.history.service.HistoryService;
 import com.project.cheerha.domain.jobOpening.dto.request.ReadJobOpeningRequestDto;
 import com.project.cheerha.domain.jobOpening.dto.response.ReadJobOpeningResponseDto;
 import com.project.cheerha.domain.jobOpening.entity.JobOpening;
@@ -24,6 +25,7 @@ public class  JobOpeningService {
     private final HistoryRepository historyRepository;
     private final UserFindByService userFindByIdService;
     private final JobOpeningFindByService jobOpeningFindByService;
+    private final HistoryService historyService;
 
     public String getJobOpeningUrlAndIncreaseViewCount(Long id) {
         JobOpening jobOpening = jobOpeningFindByService.findById(id);
@@ -50,6 +52,8 @@ public class  JobOpeningService {
         User user = userFindByIdService.findById(userId);
 
         if (requestDto.getSearchTerm() != null) {
+            historyService.saveSearchTerm(userId, requestDto.getSearchTerm());
+
             History history = History.toEntity(user, requestDto.getSearchTerm());
             historyRepository.save(history);
         }


### PR DESCRIPTION
## #️⃣ CHEERHA Board Number
118, 136
<!--- ex) #이슈번호, #이슈번호, 또는 release version -->

## 📝 요약
- Redis 적용하기 전후 성능 비교한 후, Redis에서 조회할 데이터가 없을 경우 DB에서 최근 데이터 10개 조회 후 Redis에 저장합니다.
- 검색어를 통해 조회할 시 Redis에 저장이 되고 30분마다 Redis에 추가된 데이터가 DB에 중복되지 않을 경우 DB에 저장됩니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문
- 사용자의 최근 검색어가 ZSet(Sorted Set)에 저장되고, 사용자가 더 이상 검색하지 않는 경우 삭제될 수 있도록 TTL을 1시간으로 설정했는데 시간이 적당할까요?
- Redis에 추가적으로 저장된 검색어가 30분마다 DB와 동기화될 수 있도록 했는데, 30분 정도면 적당할까요?
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [x] 지현
- [x] 리은
- [ ] 승찬
- [ ] 주양
