### PR TITLE
KAN-223-한 번 조회된 채용 공고 정보가 다시 조회되는 오류 해결 

### DIFF
--- a/src/main/java/com/project/cheerha/domain/notice/scheduler/UserAndJobOpeningKeywordIdFetchTaskScheduler.java
+++ b/src/main/java/com/project/cheerha/domain/notice/scheduler/UserAndJobOpeningKeywordIdFetchTaskScheduler.java
@@ -25,7 +25,7 @@ public class UserAndJobOpeningKeywordIdFetchTaskScheduler {
     @Transactional
     public void fetchUserAndJobOpeningKeywordIds() {
         ZonedDateTime referenceTime = ZonedDateTime.now()
-            .minusDays(7L)
+            .minusSeconds(30L)
             .withZoneSameInstant(ZoneId.of("UTC"));
 
         Map<Long, List<String>> keywordIdToUrlList =


### PR DESCRIPTION
- 데이터를 가져오는 시간을 '조회 시간 - 30초'로 수정

## #️⃣ CHEERHA Board Number

[<!--- ex) #이슈번호, #이슈번호, 또는 release version -->](https://spring-3-jo.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-223)

## 📝 요약

한 번 조회한 채용 공고 정보는 다시 조회되지 않도록 오류 수정 
- minusDays() 메서드 대신 minusSeconds() 메서드 호출 

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [ ] 지현
- [x] 리은
- [x] 승찬
- [ ] 주양
