### PR TITLE
KAN-240-redis와-my-sql-동기화-리팩토링

### DIFF
--- a/src/main/java/com/project/cheerha/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/com/project/cheerha/domain/history/repository/HistoryRepository.java
@@ -2,12 +2,18 @@ package com.project.cheerha.domain.history.repository;
 
 import com.project.cheerha.domain.history.entity.History;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
     List<History> findTop10ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("SELECT h.name FROM History h WHERE h.user.id = :userId")
+    Set<String> findNamesByUserId(@Param("userId") Long userId);
 
     boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryScheduler.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Set;
 
 @Component
@@ -23,6 +24,7 @@ public class HistoryScheduler {
      * Redis에 저장된 검색를 주기적으로 DB에 저장하는 스케줄러 메서드입니다.
      *
      * 30분마다 실행이 되며, 각 사용자의 검색어를 Redis에서 가져와서 DB에 저장합니다.
+     * 각 사용자의 기존 검색어를 조회하여 Redis에 저장된 검색어와 비교합니다.
      * 이미 저장된 검색어는 중복 저장하지 않습니다.
      */
     @Scheduled(fixedRate = 1800000) // 30분마다 실행
@@ -34,14 +36,22 @@ public class HistoryScheduler {
                 Long userId = Long.parseLong(key.split(":")[1]);
                 User user = userFindByService.findById(userId);
 
-                Set<String> searchTerms = redisTemplate.opsForZSet().range(key, 0, -1);
+                Set<String> searchTermSet = redisTemplate.opsForZSet().range(key, 0, -1);
 
-                if (searchTerms != null) {
-                    searchTerms.forEach(term -> {
-                        if (!historyRepository.existsByUserIdAndName(userId, term)) {
-                            historyRepository.save(History.toEntity(user, term));
-                        }
-                    });
+                if (searchTermSet != null && !searchTermSet.isEmpty()) {
+                    // 해당 유저의 기존 검색어 조회
+                    Set<String> existingSearchTermSet = historyRepository.findNamesByUserId(userId);
+
+                    // 중복되지 않은 검색어 필터링
+                    List<History> historyList = searchTermSet.stream()
+                        .filter(term -> !existingSearchTermSet.contains(term))
+                        .map(term -> History.toEntity(user, term))
+                        .toList();
+
+                    // 새로운 검색어가 있다면 저장
+                    if (!historyList.isEmpty()) {
+                        historyRepository.saveAll(historyList);
+                    }
                 }
             }
         }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryScheduler.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryScheduler.java
@@ -31,27 +31,25 @@ public class HistoryScheduler {
     public void saveSearchHistoryToDb() {
         Set<String> keys = redisTemplate.keys("user:*:search_history");
 
-        if (keys != null) {
-            for (String key : keys) {
-                Long userId = Long.parseLong(key.split(":")[1]);
-                User user = userFindByService.findById(userId);
+        for (String key : keys) {
+            Long userId = Long.parseLong(key.split(":")[1]);
+            User user = userFindByService.findById(userId);
 
-                Set<String> searchTermSet = redisTemplate.opsForZSet().range(key, 0, -1);
+            Set<String> searchTermSet = redisTemplate.opsForZSet().range(key, 0, -1);
 
-                if (searchTermSet != null && !searchTermSet.isEmpty()) {
-                    // 해당 유저의 기존 검색어 조회
-                    Set<String> existingSearchTermSet = historyRepository.findNamesByUserId(userId);
+            if (searchTermSet != null && !searchTermSet.isEmpty()) {
+                // 해당 유저의 기존 검색어 조회
+                Set<String> existingSearchTermSet = historyRepository.findNamesByUserId(userId);
 
-                    // 중복되지 않은 검색어 필터링
-                    List<History> historyList = searchTermSet.stream()
-                        .filter(term -> !existingSearchTermSet.contains(term))
-                        .map(term -> History.toEntity(user, term))
-                        .toList();
+                // 중복되지 않은 검색어 필터링
+                List<History> historyList = searchTermSet.stream()
+                    .filter(term -> !existingSearchTermSet.contains(term))
+                    .map(term -> History.toEntity(user, term))
+                    .toList();
 
-                    // 새로운 검색어가 있다면 저장
-                    if (!historyList.isEmpty()) {
-                        historyRepository.saveAll(historyList);
-                    }
+                // 새로운 검색어가 있다면 저장
+                if (!historyList.isEmpty()) {
+                    historyRepository.saveAll(historyList);
                 }
             }
         }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
@@ -59,19 +59,29 @@ public class HistoryService {
 
         Set<String> searchTerms = redisTemplate.opsForZSet().reverseRange(key, 0, 9);
         if (searchTerms == null || searchTerms.isEmpty()) {
-            List<String> dbSearchTerms = historyRepository.findTop10ByUserIdOrderByCreatedAtDesc(userId)
-                .stream()
-                .sorted(Comparator.comparing(History::getCreatedAt))
-                .map(History::getName)
-                .collect(Collectors.toList());
-
-            dbSearchTerms.forEach(term -> saveSearchTerm(userId, term));
-            Collections.reverse(dbSearchTerms);
-
-            return dbSearchTerms;
+            return fetchAndCacheSearchHistory(userId);
         }
 
         return new ArrayList<>(searchTerms);
+    }
+
+    /**
+     * 사용자의 최근 검색 기록을 DB에서 조회하여 Redis에 캐싱한 후 반환한다.
+     *
+     * Redis에 검색 기록이 없는 경우, 이 메서드를 호출하여 DB에서 데이터를 가져온다.
+     * 가져온 데이터를 Redis에 저장하여 이후 빠른 검색을 가능하게 한다.
+     */
+    private List<String> fetchAndCacheSearchHistory(Long userId) {
+        List<String> dbSearchTerms = historyRepository.findTop10ByUserIdOrderByCreatedAtDesc(userId)
+            .stream()
+            .sorted(Comparator.comparing(History::getCreatedAt))
+            .map(History::getName)
+            .collect(Collectors.toList());
+
+        dbSearchTerms.forEach(term -> saveSearchTerm(userId, term));
+        Collections.reverse(dbSearchTerms);
+
+        return dbSearchTerms;
     }
 
 }

--- a/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
+++ b/src/main/java/com/project/cheerha/domain/history/service/HistoryService.java
@@ -59,7 +59,7 @@ public class HistoryService {
 
         Set<String> searchTerms = redisTemplate.opsForZSet().reverseRange(key, 0, 9);
         if (searchTerms == null || searchTerms.isEmpty()) {
-            return fetchAndCacheSearchHistory(userId);
+            return dbSearchTermList(userId);
         }
 
         return new ArrayList<>(searchTerms);
@@ -71,7 +71,7 @@ public class HistoryService {
      * Redis에 검색 기록이 없는 경우, 이 메서드를 호출하여 DB에서 데이터를 가져온다.
      * 가져온 데이터를 Redis에 저장하여 이후 빠른 검색을 가능하게 한다.
      */
-    private List<String> fetchAndCacheSearchHistory(Long userId) {
+    private List<String> dbSearchTermList(Long userId) {
         List<String> dbSearchTerms = historyRepository.findTop10ByUserIdOrderByCreatedAtDesc(userId)
             .stream()
             .sorted(Comparator.comparing(History::getCreatedAt))

--- a/src/test/java/com/project/cheerha/domain/history/service/historyUserAndJobOpeningKeywordIdFetchTaskSchedulerTest.java
+++ b/src/test/java/com/project/cheerha/domain/history/service/historyUserAndJobOpeningKeywordIdFetchTaskSchedulerTest.java
@@ -59,14 +59,14 @@ public class historyUserAndJobOpeningKeywordIdFetchTaskSchedulerTest {
         );
         when(userFindByService.findById(1L)).thenReturn(mockUser);
 
-        when(historyRepository.existsByUserIdAndName(1L, "Redis")).thenReturn(false);
-        when(historyRepository.existsByUserIdAndName(1L, "Java")).thenReturn(true);
+        Set<String> existingSearchTermSet = Set.of("Java");
+        when(historyRepository.findNamesByUserId(1L)).thenReturn(existingSearchTermSet);
 
         // when
         historyScheduler.saveSearchHistoryToDb();
 
         // then
-        verify(historyRepository,times(1)).save(any(History.class));
+        verify(historyRepository,times(1)).saveAll(anyList());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ CHEERHA Board Number

https://spring-3-jo.atlassian.net/browse/KAN-240
<!--- ex) #이슈번호, #이슈번호, 또는 release version -->

## 📝 요약
- Redis와 MySQL 동기화하는 로직에서 사용자별 기존 검색어 조회를 한번에 할 수 있도록 수정했습니다.
- 최근 검색 기록을 DB에서 조회하여 Redis에 반환하는 메서드를 분리했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [x] 지현
- [x] 리은
- [ ] 승찬
- [ ] 주양
