### PR TITLE
KAN-217-관리자권한-분리-db-migration-api 외

### DIFF
--- a/src/main/java/com/project/cheerha/common/filter/JwtFilter.java
+++ b/src/main/java/com/project/cheerha/common/filter/JwtFilter.java
@@ -90,6 +90,14 @@ public class JwtFilter implements Filter {
                 httpRequest.setAttribute("userRole", role);
             }
 
+            if ("/syncData".equals(url)) {
+                Role role = (Role) httpRequest.getAttribute("userRole");
+                if (role == null || !role.equals(Role.ADMIN)) {
+                    filterExceptionHandler.sendErrorResponse(httpResponse, HttpStatus.FORBIDDEN, "관리자만 접근 가능합니다.");
+                    return;
+                }
+            }
+
             chain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             log.error("Expired JWT token, 만료된 JWT token 입니다.", e);

--- a/src/main/java/com/project/cheerha/common/filter/JwtFilter.java
+++ b/src/main/java/com/project/cheerha/common/filter/JwtFilter.java
@@ -29,7 +29,7 @@ import org.springframework.util.PatternMatchUtils;
 public class JwtFilter implements Filter {
 
     private static final String[] WHITE_LIST = {
-            "/auth/signup", "/auth/login", "/actuator/health", "/actuator/prometheus",
+            "/auth/signup", "/auth/signup-verify", "/auth/login", "/actuator/health", "/actuator/prometheus",
             "/users/email-verification/send-password-reset-verify", "/users/email-verification/password-reset-verify",
             "/users/password/reset"};
     private final JwtSecurityProperties securityProperties;

--- a/src/main/java/com/project/cheerha/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/cheerha/domain/auth/controller/AuthController.java
@@ -3,10 +3,8 @@ package com.project.cheerha.domain.auth.controller;
 import com.project.cheerha.common.dto.ApiResponseDto;
 import com.project.cheerha.domain.auth.dto.request.CreateLoginRequestDto;
 import com.project.cheerha.domain.auth.dto.request.CreateSignupRequestDto;
-import com.project.cheerha.domain.auth.dto.response.CreateLoginResponseDto;
-import com.project.cheerha.domain.auth.dto.response.CreateLogoutResponseDto;
-import com.project.cheerha.domain.auth.dto.response.CreateSignupResponseDto;
-import com.project.cheerha.domain.auth.dto.response.RefreshAccessTokenResponseDto;
+import com.project.cheerha.domain.auth.dto.request.VerifySignupRequestDto;
+import com.project.cheerha.domain.auth.dto.response.*;
 import com.project.cheerha.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +22,12 @@ public class AuthController {
     public ResponseEntity<ApiResponseDto<CreateSignupResponseDto>> signup(
             @Valid @RequestBody CreateSignupRequestDto dto) {
         return ApiResponseDto.created(authService.signup(dto));
+    }
+
+    @PostMapping("/signup-verify")
+    public ResponseEntity<ApiResponseDto<VerifySignupResponseDto>> verifySignup(
+            @Valid @RequestBody VerifySignupRequestDto dto){
+        return ApiResponseDto.created(authService.verifySignup(dto));
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/project/cheerha/domain/auth/dto/request/CreateSignupRequestDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/request/CreateSignupRequestDto.java
@@ -3,10 +3,6 @@ package com.project.cheerha.domain.auth.dto.request;
 import jakarta.validation.constraints.*;
 
 public record CreateSignupRequestDto(
-    @Email String email,
-    @NotBlank String password,
-    @NotBlank String name,
-    @NotNull @Min(20) @Max(80) int age,
-    @NotNull @Min(0) @Max(50) int career
+    @Email String email
 ) {
 }

--- a/src/main/java/com/project/cheerha/domain/auth/dto/request/VerifySignupRequestDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/request/VerifySignupRequestDto.java
@@ -4,8 +4,7 @@ import jakarta.validation.constraints.*;
 
 public record VerifySignupRequestDto(
     @Email String email,
-    //8글자 이상, 영소문자, 특수문자, 숫자 각 1개 이상
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[\\W_]).{8,}$") @NotBlank String password,
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[\\W_]).{8,}$", message = "올바른 비밀번호가 아닙니다.") @NotBlank String password,
     @NotBlank String name,
     @NotNull @Min(20) @Max(80) int age,
     @NotNull @Min(0) @Max(50) int career,

--- a/src/main/java/com/project/cheerha/domain/auth/dto/request/VerifySignupRequestDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/request/VerifySignupRequestDto.java
@@ -1,0 +1,13 @@
+package com.project.cheerha.domain.auth.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record VerifySignupRequestDto(
+    @Email String email,
+    @NotBlank String password,
+    @NotBlank String name,
+    @NotNull @Min(20) @Max(80) int age,
+    @NotNull @Min(0) @Max(50) int career,
+    String token
+) {
+}

--- a/src/main/java/com/project/cheerha/domain/auth/dto/request/VerifySignupRequestDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/request/VerifySignupRequestDto.java
@@ -4,7 +4,8 @@ import jakarta.validation.constraints.*;
 
 public record VerifySignupRequestDto(
     @Email String email,
-    @NotBlank String password,
+    //8글자 이상, 영소문자, 특수문자, 숫자 각 1개 이상
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[\\W_]).{8,}$") @NotBlank String password,
     @NotBlank String name,
     @NotNull @Min(20) @Max(80) int age,
     @NotNull @Min(0) @Max(50) int career,

--- a/src/main/java/com/project/cheerha/domain/auth/dto/response/CreateSignupResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/response/CreateSignupResponseDto.java
@@ -4,6 +4,6 @@ public record CreateSignupResponseDto(
     String message
 ) {
     public static CreateSignupResponseDto toDto() {
-        return new CreateSignupResponseDto("회원가입 성공");
+        return new CreateSignupResponseDto("이메일 인증코드가 발송되었습니다.");
     }
 }

--- a/src/main/java/com/project/cheerha/domain/auth/dto/response/CreateSignupResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/response/CreateSignupResponseDto.java
@@ -4,6 +4,6 @@ public record CreateSignupResponseDto(
     String message
 ) {
     public static CreateSignupResponseDto toDto() {
-        return new CreateSignupResponseDto("이메일 인증코드가 발송되었습니다.");
+        return new CreateSignupResponseDto("이메일 인증토큰이 발송되었습니다.");
     }
 }

--- a/src/main/java/com/project/cheerha/domain/auth/dto/response/VerifySignupResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/auth/dto/response/VerifySignupResponseDto.java
@@ -1,0 +1,9 @@
+package com.project.cheerha.domain.auth.dto.response;
+
+public record VerifySignupResponseDto(
+    String message
+) {
+    public static VerifySignupResponseDto toDto() {
+        return new VerifySignupResponseDto("회원가입 성공");
+    }
+}

--- a/src/main/java/com/project/cheerha/domain/auth/entity/BannedEmail.java
+++ b/src/main/java/com/project/cheerha/domain/auth/entity/BannedEmail.java
@@ -21,8 +21,6 @@ public class BannedEmail {
 
     private ZonedDateTime createdAt = ZonedDateTime.now();
 
-    private boolean isDeleted = false;
-
     public static BannedEmail toEntity(String email, String message) {
         BannedEmail bannedIp = new BannedEmail();
         bannedIp.email = email;

--- a/src/main/java/com/project/cheerha/domain/auth/repository/BannedEmailRepository.java
+++ b/src/main/java/com/project/cheerha/domain/auth/repository/BannedEmailRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BannedEmailRepository extends JpaRepository<BannedEmail, Long> {
     boolean existsByEmail(String email);
+
+    void deleteByEmail(String email);
 }

--- a/src/main/java/com/project/cheerha/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/cheerha/domain/auth/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
     private final VerificationEmailSender verificationEmailSender;
     private final EmailTokenService emailTokenService;
 
-    private static final String SIGNUP_TOKEN_PREFIX = "signup_email_verification_token";
+    public static final String SIGNUP_TOKEN_PREFIX = "signup_email_verification_token";
 
     /**
      * 회원가입 처리하는 메서드

--- a/src/main/java/com/project/cheerha/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/cheerha/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.project.cheerha.domain.auth.service;
 
+import com.project.cheerha.common.email.sender.VerificationEmailSender;
 import com.project.cheerha.common.exception.auth.AuthErrorCode;
 import com.project.cheerha.common.exception.auth.UnAuthorizedException;
 import com.project.cheerha.common.exception.client.BadRequestException;
@@ -7,14 +8,13 @@ import com.project.cheerha.common.exception.client.ClientErrorCode;
 import com.project.cheerha.common.properties.JwtSecurityProperties;
 import com.project.cheerha.common.redis.auth.RedisBlackListService;
 import com.project.cheerha.common.redis.auth.RedisRefreshTokenService;
+import com.project.cheerha.common.redis.email.EmailTokenService;
 import com.project.cheerha.common.util.JwtUtil;
 import com.project.cheerha.common.util.PasswordEncoder;
 import com.project.cheerha.domain.auth.dto.request.CreateLoginRequestDto;
 import com.project.cheerha.domain.auth.dto.request.CreateSignupRequestDto;
-import com.project.cheerha.domain.auth.dto.response.CreateLoginResponseDto;
-import com.project.cheerha.domain.auth.dto.response.CreateLogoutResponseDto;
-import com.project.cheerha.domain.auth.dto.response.CreateSignupResponseDto;
-import com.project.cheerha.domain.auth.dto.response.RefreshAccessTokenResponseDto;
+import com.project.cheerha.domain.auth.dto.request.VerifySignupRequestDto;
+import com.project.cheerha.domain.auth.dto.response.*;
 import com.project.cheerha.domain.user.entity.User;
 import com.project.cheerha.domain.user.repository.UserRepository;
 import com.project.cheerha.domain.user.service.UserFindByService;
@@ -34,6 +34,10 @@ public class AuthService {
     private final RedisRefreshTokenService redisRefreshTokenService;
     private final RedisBlackListService redisBlackListService;
     private final UserFindByService userFindByService;
+    private final VerificationEmailSender verificationEmailSender;
+    private final EmailTokenService emailTokenService;
+
+    private static final String SIGNUP_TOKEN_PREFIX = "signup_email_verification_token";
 
     /**
      * 회원가입 처리하는 메서드
@@ -43,17 +47,24 @@ public class AuthService {
         if (userRepository.existsByEmail(dto.email())) {
             throw new BadRequestException(ClientErrorCode.ALREADY_EXIST_EMAIL);
         }
+        String token = emailTokenService.saveToken(SIGNUP_TOKEN_PREFIX, dto.email());
+        verificationEmailSender.sendVerificationEmail(dto.email(), token);
+        return CreateSignupResponseDto.toDto();
+    }
+
+    public VerifySignupResponseDto verifySignup(VerifySignupRequestDto dto) {
+        emailTokenService.verifyEmailToken(SIGNUP_TOKEN_PREFIX, dto.email(), dto.token());
         String encodedPassword = passwordEncoder.encode(dto.password());
 
         User user = User.toEntity(
-            dto.email(),
-            dto.name(),
-            dto.age(),
-            dto.career(),
-            encodedPassword
+                dto.email(),
+                dto.name(),
+                dto.age(),
+                dto.career(),
+                encodedPassword
         );
         userRepository.save(user);
-        return CreateSignupResponseDto.toDto();
+        return VerifySignupResponseDto.toDto();
     }
 
     /**

--- a/src/main/java/com/project/cheerha/domain/user/dto/response/UpdatePasswordResponseDto.java
+++ b/src/main/java/com/project/cheerha/domain/user/dto/response/UpdatePasswordResponseDto.java
@@ -2,6 +2,6 @@ package com.project.cheerha.domain.user.dto.response;
 
 public record UpdatePasswordResponseDto(String message) {
     public static UpdatePasswordResponseDto toDto() {
-        return new UpdatePasswordResponseDto("비밀번호가 변경되었습니다.");
+        return new UpdatePasswordResponseDto("비밀번호가 리셋되었습니다.");
     }
 }

--- a/src/main/java/com/project/cheerha/domain/user/service/UserPasswordService.java
+++ b/src/main/java/com/project/cheerha/domain/user/service/UserPasswordService.java
@@ -5,6 +5,7 @@ import com.project.cheerha.common.exception.client.ClientErrorCode;
 import com.project.cheerha.common.exception.data.DataErrorCode;
 import com.project.cheerha.common.exception.data.NotFoundException;
 import com.project.cheerha.common.util.PasswordEncoder;
+import com.project.cheerha.domain.auth.repository.BannedEmailRepository;
 import com.project.cheerha.domain.user.dto.request.ResetPasswordRequestDto;
 import com.project.cheerha.domain.user.dto.request.UpdatePasswordRequestDto;
 import com.project.cheerha.domain.user.dto.response.UpdatePasswordResponseDto;
@@ -23,6 +24,7 @@ public class UserPasswordService {
     private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, String> redisTemplate;
     private final UserRepository userRepository;
+    private final BannedEmailRepository bannedEmailRepository;
 
     private static final String PASSWORD_TOKEN_PREFIX = "password_verification";
 
@@ -40,7 +42,7 @@ public class UserPasswordService {
     }
 
     /**
-     * 비로그인 사용자의 패스워드 리셋
+     * 비로그인 사용자의 패스워드 리셋 또는 이메일 밴 삭제
      * @param requestDto 이메일, 토큰, 새 비밀번호
      */
     @Transactional
@@ -59,6 +61,9 @@ public class UserPasswordService {
         user.updatePassword(passwordEncoder.encode(requestDto.newPassword()));
 
         redisTemplate.delete(redisKey);
+        if (bannedEmailRepository.existsByEmail(requestDto.email())) {
+            bannedEmailRepository.deleteByEmail(requestDto.email());
+        }
         return UpdatePasswordResponseDto.toDto();
     }
 }

--- a/src/test/java/com/project/cheerha/auth/SignupTest.java
+++ b/src/test/java/com/project/cheerha/auth/SignupTest.java
@@ -4,7 +4,6 @@ import com.project.cheerha.common.email.sender.VerificationEmailSender;
 import com.project.cheerha.common.exception.client.BadRequestException;
 import com.project.cheerha.common.exception.client.ClientErrorCode;
 import com.project.cheerha.common.redis.email.EmailTokenService;
-import com.project.cheerha.common.util.PasswordEncoder;
 import com.project.cheerha.domain.auth.dto.request.CreateSignupRequestDto;
 import com.project.cheerha.domain.auth.dto.response.CreateSignupResponseDto;
 import com.project.cheerha.domain.auth.service.AuthService;

--- a/src/test/java/com/project/cheerha/auth/SignupTest.java
+++ b/src/test/java/com/project/cheerha/auth/SignupTest.java
@@ -1,12 +1,13 @@
 package com.project.cheerha.auth;
 
+import com.project.cheerha.common.email.sender.VerificationEmailSender;
 import com.project.cheerha.common.exception.client.BadRequestException;
 import com.project.cheerha.common.exception.client.ClientErrorCode;
+import com.project.cheerha.common.redis.email.EmailTokenService;
 import com.project.cheerha.common.util.PasswordEncoder;
 import com.project.cheerha.domain.auth.dto.request.CreateSignupRequestDto;
 import com.project.cheerha.domain.auth.dto.response.CreateSignupResponseDto;
 import com.project.cheerha.domain.auth.service.AuthService;
-import com.project.cheerha.domain.user.entity.User;
 import com.project.cheerha.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,41 +25,34 @@ public class SignupTest {
     private UserRepository userRepository;
 
     @Mock
-    private PasswordEncoder passwordEncoder;
+    private EmailTokenService emailTokenService;
+
+    @Mock
+    private VerificationEmailSender verificationEmailSender;
 
     @InjectMocks
     private AuthService authService;
 
     @Test
-    void testSignup_가입에_성공했을때() {
+    void testSignup_이메일전송에_성공했을때() {
         //given
         CreateSignupRequestDto dto = new CreateSignupRequestDto(
-                "test@example.com",
-                "password",
-                "tester",
-                20,
-                0
+                "test@example.com"
                 );
         when(userRepository.existsByEmail(dto.email())).thenReturn(false);
-        when(passwordEncoder.encode(dto.password())).thenReturn("encodedPassword");
 
         //when
         CreateSignupResponseDto response = authService.signup(dto);
 
         //then
         assertNotNull(response);
-        verify(userRepository, times(1)).save(any(User.class));
     }
 
     @Test
     void testSignup_이미_존재하는_이메일일때() {
         //given
         CreateSignupRequestDto dto = new CreateSignupRequestDto(
-                "test@example.com",
-                "password123",
-                "tester",
-                20,
-                0
+                "test@example.com"
         );
         when(userRepository.existsByEmail(dto.email())).thenReturn(true);
 

--- a/src/test/java/com/project/cheerha/auth/VerifySignupTest.java
+++ b/src/test/java/com/project/cheerha/auth/VerifySignupTest.java
@@ -1,5 +1,7 @@
 package com.project.cheerha.auth;
 
+import com.project.cheerha.common.exception.client.BadRequestException;
+import com.project.cheerha.common.exception.client.ClientErrorCode;
 import com.project.cheerha.common.redis.email.EmailTokenService;
 import com.project.cheerha.common.util.PasswordEncoder;
 import com.project.cheerha.domain.auth.dto.request.VerifySignupRequestDto;
@@ -17,12 +19,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Map;
 
 import static com.project.cheerha.domain.auth.service.AuthService.SIGNUP_TOKEN_PREFIX;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class VerifySignupTest {
@@ -66,5 +67,23 @@ public class VerifySignupTest {
         verify(passwordEncoder).encode(dto.password());
         verify(userRepository).save(any(User.class));
         assertNotNull(response);
+    }
+
+    @Test
+    void verifySignup_토큰_불일치() {
+        //Given
+        VerifySignupRequestDto dto = new VerifySignupRequestDto(
+                "test@example.com", "password", "testUser", 25, 0, "invalidToken"
+        );
+        doThrow(new BadRequestException(ClientErrorCode.INVALID_EMAIL_VERIFICATION_TOKEN))
+                .when(emailTokenService)
+                .verifyEmailToken(anyString(), anyString(), anyString());
+
+        //When & Then
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            authService.verifySignup(dto);
+        });
+        assertEquals("이메일 인증 토큰이 유효하지 않습니다.", exception.getMessage());
+        verify(userRepository, never()).save(any(User.class));
     }
 }

--- a/src/test/java/com/project/cheerha/auth/VerifySignupTest.java
+++ b/src/test/java/com/project/cheerha/auth/VerifySignupTest.java
@@ -1,0 +1,70 @@
+package com.project.cheerha.auth;
+
+import com.project.cheerha.common.redis.email.EmailTokenService;
+import com.project.cheerha.common.util.PasswordEncoder;
+import com.project.cheerha.domain.auth.dto.request.VerifySignupRequestDto;
+import com.project.cheerha.domain.auth.dto.response.VerifySignupResponseDto;
+import com.project.cheerha.domain.auth.service.AuthService;
+import com.project.cheerha.domain.user.entity.User;
+import com.project.cheerha.domain.user.repository.UserRepository;
+import com.project.cheerha.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static com.project.cheerha.domain.auth.service.AuthService.SIGNUP_TOKEN_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class VerifySignupTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private EmailTokenService emailTokenService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void verifySignup_인증에_성공하고_유저_저장() {
+        // Given
+        VerifySignupRequestDto dto = new VerifySignupRequestDto(
+                "test@example.com", "password", "testUser", 25, 0, "token"
+        );
+
+        String encodedPassword = "encodedPassword123";
+        User mockUser = TestUtils.spy(User.class, Map.of(
+                "email", "test@example.com",
+                "password", encodedPassword,
+                "name", "testUser",
+                "age", 25,
+                "career", 0
+        ));
+        willDoNothing().given(emailTokenService).verifyEmailToken(anyString(), anyString(), anyString());
+        when(passwordEncoder.encode(dto.password())).thenReturn(encodedPassword);
+        when(userRepository.save(any(User.class))).thenReturn(mockUser);
+
+        //When
+        VerifySignupResponseDto response = authService.verifySignup(dto);
+
+        //Then
+        verify(emailTokenService).verifyEmailToken(SIGNUP_TOKEN_PREFIX, dto.email(), dto.token());
+        verify(passwordEncoder).encode(dto.password());
+        verify(userRepository).save(any(User.class));
+        assertNotNull(response);
+    }
+}


### PR DESCRIPTION
## #️⃣ CHEERHA Board Number

https://spring-3-jo.atlassian.net/browse/KAN-217
https://spring-3-jo.atlassian.net/browse/KAN-221
https://spring-3-jo.atlassian.net/browse/KAN-247

## 📝 요약

DB -> ElasticSearch Migration api filter에서 권한설정(ADMIN)
회원가입 시 이메일 인증 구현
밴 당한 사용자가 비밀번호 리셋 시 밴 풀리도록 구현
모두 테스트 완료, 테스트코드 수정/작성
패스워드 유효성검사 생성

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [x] 지현
- [ ] 리은
- [x] 승찬
- [ ] 주양
