### PR TITLE
KAN-201-연령별-인기-즐겨찾기-상위-10개-조회-쿼리-최적화

### DIFF
--- a/src/main/java/com/project/cheerha/domain/bookmark/repository/BookmarkRepositoryQueryImpl.java
+++ b/src/main/java/com/project/cheerha/domain/bookmark/repository/BookmarkRepositoryQueryImpl.java
@@ -3,11 +3,9 @@ package com.project.cheerha.domain.bookmark.repository;
 import static com.project.cheerha.domain.bookmark.entity.QBookmark.bookmark;
 import static com.project.cheerha.domain.jobopening.entity.QJobOpening.jobOpening;
 import static com.project.cheerha.domain.user.entity.QUser.user;
-import static com.querydsl.jpa.JPAExpressions.select;
 
 import com.project.cheerha.domain.bookmark.dto.response.BookmarkCustomAgeResponseDto;
 import com.project.cheerha.domain.bookmark.dto.response.QBookmarkCustomAgeResponseDto;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -21,64 +19,44 @@ public class BookmarkRepositoryQueryImpl implements BookmarkRepositoryQuery {
     private final JPAQueryFactory jpaQueryFactory;
 
     /**
-     * 사용자가 원하는 연령대의 사람들이 추가한 즐겨찾기를 상위 10개까지 보여주는 데 사용되는 로직입니다.
-     * QueryDSL을 사용하여 bookmark에 있는 정보를 조회합니다.
-     * bookmark에는 식별자, user식별자, jobopening 식별자만 존재합니다. (PK인 id와 FK만 2개 존재)
-     * join을 사용하여 FK가 있는 user와 jobOpening의 정보도 조회할 수 있게 합니다.
-     * user에서 연령대 정보를 가져오면서 between으로 최대연령과 최소연령을 사용자가 입력한 값으로 특정합니다.
-     * 특정된 연령대에서 즐겨찾기 된 jobOpening의 정보들과 함께 서브쿼리를 사용하여 해당 즐겨찾기를 추가한 횟수를 count한 정보까지 보여줍니다.
-     * 이 때 서브쿼리에서도 join과 where절을 사용하여 user 연령대, jobopening 정보까지 동일한 경우에만 count 되도록 설정합니다.
-     * ExpressionUtils.as를 사용하여 별칭을 설정하여주고, 해당 별칭으로 전체 쿼리 조회 시 기준을 해당 count 값으로 내림차순 합니다.
-     * limit을 10으로 걸어서 상위 10개만 보여주고 나머지를 안 보이게 설정합니다.
-     * @return 상위 내용을 return 합니다.
+     * 사용자가 입력한 연령대에 해당하는 사람들이 즐겨찾기한 상위 10개의 jobOpening 정보를 조회하는 로직입니다.
+     * QueryDSL을 사용하여 bookmark 엔티티에 대한 정보를 조회하며, jobOpening과 user 엔티티를 조인합니다.
+     * bookmark 테이블은 식별자(id), user 식별자(userId), jobOpening 식별자(jobOpeningId)로 구성되어 있으며,
+     * 각각의 외래 키를 통해 user와 jobOpening 테이블을 조인하여 관련 정보를 가져옵니다.
+     * 사용자가 입력한 연령대(minAge, maxAge) 조건에 맞는 user 정보를 기준으로 즐겨찾기(bookmark)를 필터링합니다.
+     * 연령대 필터링은 `user.age.between(minAge, maxAge)`로 처리됩니다.
+     * `Expressions.numberTemplate`을 사용한 즐겨찾기 수(count)를 기준으로 내림차순으로 정렬합니다.
+     * 결과적으로, 조건에 맞는 상위 10개의 즐겨찾기된 jobOpening을 조회하며, `limit(10)`으로 상위 10개만 결과로 반환됩니다.
+     * @param minAge 사용자가 설정한 최소 연령
+     * @param maxAge 사용자가 설정한 최대 연령
+     * @return 사용자가 입력한 연령대에서 즐겨찾기된 상위 10개의 jobOpening 정보
      */
     @Override
     public List<BookmarkCustomAgeResponseDto> readTop10BookmarksByAgeBetween(int minAge, int maxAge) {
 
         return jpaQueryFactory.select(
-            new QBookmarkCustomAgeResponseDto(
-                jobOpening.id,
-                jobOpening.title,
-                jobOpening.company,
-                jobOpening.educationLevel,
-                jobOpening.employmentType,
-                jobOpening.hiringStartAt,
-                jobOpening.hiringEndAt,
-                jobOpening.position,
-                jobOpening.salary,
-                jobOpening.minExperienceYears,
-                jobOpening.maxExperienceYears,
-                ExpressionUtils.as(
-                    select(bookmark.id.count())
-                        .from(bookmark)
-                        .join(bookmark.user, user)
-                        .join(bookmark.jobOpening)
-                        .where(user.age.between(minAge, maxAge)
-                            .and(bookmark.jobOpening.id.eq(jobOpening.id))),
-                    "bookmarkCount"
+                        new QBookmarkCustomAgeResponseDto(
+                                jobOpening.id,
+                                jobOpening.title,
+                                jobOpening.company,
+                                jobOpening.educationLevel,
+                                jobOpening.employmentType,
+                                jobOpening.hiringStartAt,
+                                jobOpening.hiringEndAt,
+                                jobOpening.position,
+                                jobOpening.salary,
+                                jobOpening.minExperienceYears,
+                                jobOpening.maxExperienceYears,
+                                Expressions.numberTemplate(Long.class, "COUNT({0})", bookmark.id).as("bookmarkCount")
+                        )
                 )
-            ))
-            .from(bookmark)
-            .join(bookmark.jobOpening,jobOpening)
-            .join(bookmark.user,user)
-            .where(user.age.between(minAge,maxAge))
-            .groupBy(
-                jobOpening.id,
-                jobOpening.title,
-                jobOpening.company,
-                jobOpening.educationLevel,
-                jobOpening.employmentType,
-                jobOpening.hiringStartAt,
-                jobOpening.hiringEndAt,
-                jobOpening.position,
-                jobOpening.salary,
-                jobOpening.minExperienceYears,
-                jobOpening.maxExperienceYears
-            )
-            .orderBy(
-                Expressions.numberPath(Long.class, "bookmarkCount").desc()
-            )
-            .limit(10)
-            .fetch();
+                .from(bookmark)
+                .join(bookmark.jobOpening, jobOpening)
+                .join(bookmark.user, user)
+                .where(user.age.between(minAge, maxAge))
+                .groupBy(jobOpening.id)
+                .orderBy(Expressions.numberPath(Long.class, "bookmarkCount").desc())
+                .limit(10)
+                .fetch();
     }
 }


### PR DESCRIPTION
## #️⃣ CHEERHA Board Number

<!--- ex) #이슈번호, #이슈번호, 또는 release version -->
https://spring-3-jo.atlassian.net/browse/KAN-201

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
쿼리 리팩토링: 기존  서브쿼리 사용-> 단일쿼리로 변경 (조회 응답속도- 서브쿼리: 3초 62ms → 단일쿼리: 376ms)
age 컬럼에 인덱스 미적용: 중복되는 age 데이터가 많아 인덱스가 효율적으로 작동하지 않음(조회속도 느려짐)

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [ ] 지현
- [ ] 리은
- [x] 승찬
- [x] 주양
