### PR TITLE
KAN-267-KeywordFindByService에서-키워드-단건-조회-실패-테스트-코드-작성

### DIFF
--- a/src/test/java/com/project/cheerha/domain/keyword/service/KeywordFindByServiceTest.java
+++ b/src/test/java/com/project/cheerha/domain/keyword/service/KeywordFindByServiceTest.java
@@ -1,0 +1,56 @@
+package com.project.cheerha.domain.keyword.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.cheerha.common.exception.data.DataErrorCode;
+import com.project.cheerha.common.exception.data.NotFoundException;
+import com.project.cheerha.domain.keyword.repository.KeywordRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class KeywordFindByServiceTest {
+
+    @Mock
+    private KeywordRepository keywordRepository;
+
+    @InjectMocks
+    private KeywordFindByService keywordFindByService;
+
+    @DisplayName("실패 - 존재하지 않는 keywordId로 키워드 조회 시 NotFoundException 발생")
+    @Test
+    void failsToFindKeywordById() {
+        // given
+        // 존재하지 않는 키워드 ID 설정
+        Long notExistingKeywordId = 999L;
+
+        // 존재하지 않는 ID로 조회 시 빈 결과 반환
+        when(keywordRepository.findById(notExistingKeywordId))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        // 존재하지 않는 ID로 조회 시 NotFoundException 발생하는지 검증
+        NotFoundException expectedException = assertThrows(
+            NotFoundException.class,
+            () -> keywordFindByService.findById(notExistingKeywordId)
+        );
+
+        // 예외 메시지가 예상한 메시지와 같은지 확인
+        String actualMessage = expectedException.getMessage();
+        String expectedMessage = DataErrorCode.KEYWORD_NOT_FOUND.getMessage();
+        assertThat(actualMessage).isEqualTo(expectedMessage);
+
+        // findById가 정확히 한 번 호출되었는지 검증
+        verify(keywordRepository, times(1))
+            .findById(notExistingKeywordId);
+    }
+}


### PR DESCRIPTION
## #️⃣ CHEERHA Board Number

https://spring-3-jo.atlassian.net/browse/KAN-267

## 📝 요약

KeywordFindByService에서 존재하지 않는 keywordId로 키워드 단건 조회 시 NotFoundException 발생하는 ‘조회 실패’ 테스트 코드 작성

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [ ] 지현
- [ ] 리은
- [x] 승찬
- [x] 주양
