### PR TITLE
KAN-273-실행-기한이-지난-태스크들이-자동으로-삭제되지-않는-오류

### DIFF
--- a/src/main/java/com/project/cheerha/common/scheduler/consumer/TaskConsumer.java
+++ b/src/main/java/com/project/cheerha/common/scheduler/consumer/TaskConsumer.java
@@ -24,6 +24,7 @@ public class TaskConsumer {
     private final Map<String, TaskHandler> handlers = new HashMap<>();
 
     private static final String SORTED_SET_KEY = "scheduled-tasks";
+    private static final String BUCKET_PREFIX = "scheduler:lastScheduledTime:";
     private volatile boolean isRunning = true;
 
     /**
@@ -45,8 +46,9 @@ public class TaskConsumer {
         if (!instanceManager.isLatestInstance()) {
             return;
         }
-
         if (!isRunning) return;
+        taskRepository.removeExpiredBuckets(BUCKET_PREFIX);
+        taskRepository.removeExpiredTasks(SORTED_SET_KEY);
 
         String taskDataString = taskRepository.getDueTask(SORTED_SET_KEY);
         if (taskDataString != null) {

--- a/src/main/java/com/project/cheerha/common/scheduler/repository/TaskRepository.java
+++ b/src/main/java/com/project/cheerha/common/scheduler/repository/TaskRepository.java
@@ -9,4 +9,6 @@ public interface TaskRepository {
     long getLastScheduledTime(String key, long defaultValue);
     void addScheduledTask(String key, String taskData, Instant scheduledTime);
     String getDueTask(String key);
+    void removeExpiredBuckets(String key);
+    void removeExpiredTasks(String key);
 }

--- a/src/main/java/com/project/cheerha/common/scheduler/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/project/cheerha/common/scheduler/repository/TaskRepositoryImpl.java
@@ -47,4 +47,27 @@ public class TaskRepositoryImpl implements TaskRepository {
         }
         return null;
     }
+
+    @Override
+    public void removeExpiredBuckets(String keyPrefix) {
+        long expirationThreshold = Instant.now().minusSeconds(180).toEpochMilli();
+        Iterable<String> keys = redissonClient.getKeys().getKeysByPattern(keyPrefix + "*");
+        for (String key : keys) {
+            RBucket<String> bucket = redissonClient.getBucket(key);
+            String value = bucket.get();
+            if (value != null) {
+                long timestamp = Long.parseLong(value);
+                if (timestamp < expirationThreshold) {
+                    bucket.delete();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void removeExpiredTasks(String key) {
+        RScoredSortedSet<String> sortedSet = redissonClient.getScoredSortedSet(key);
+        long expirationThreshold = Instant.now().minusSeconds(180).toEpochMilli();
+        sortedSet.removeRangeByScore(0, true, expirationThreshold, true);
+    }
 }


### PR DESCRIPTION
## #️⃣ CHEERHA Board Number

https://spring-3-jo.atlassian.net/browse/KAN-273

## 📝 요약

실행기한이 3분 이상 지난 태스크들을 자동으로 삭제하도록 수정했습니다.

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문



## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 채영
- [ ] 지현
- [ ] 리은
- [x] 승찬
- [x] 주양
